### PR TITLE
Update metadata to reflect addition of support for UNO R4 boards

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Use hardware Timer1 for finer PWM control and/or running an periodic in
 paragraph=
 category=Timing
 url=http://playground.arduino.cc/Code/Timer1
-architectures=avr
+architectures=avr,renesas,renesas_uno
 


### PR DESCRIPTION
The `architectures` field of the [`library.properties` metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata) specifies a list of architectures supported by the library.

Previously, the `renesas_uno` architecture was not included in this list, even though that architecture is supported by the library (https://github.com/delta-G/TimerOne/commit/622ac1317f41f6e4027b197cb507418b1e0339aa). This resulted in several undesirable outcomes when compiling the library for boards of that architecture:

* Display of a misleading warning when compiling the library:
  ```text
  WARNING: library TimerOne claims to run on avr architecture(s) and may be incompatible with your current board which runs on renesas_uno architecture(s).
  ```
* Library discovery phase of the [sketch build system](https://arduino.github.io/arduino-cli/latest/sketch-build-process/#dependency-resolution) giving higher priority to other installed libraries matching an `#include` directive intended to target this library.
* Library's examples placed under the Arduino IDE 1.x **File > Examples > INCOMPATIBLE** menu.

These problems are resolved by adding the missing architectures to the `architectures` field.

When installed via Boards manager, the "**Arduino R4 UNO Boards**" platform has the architecture `renesas_uno`. This platform is part of the [`arduino/ArduinoCore-renesas`](https://github.com/arduino/ArduinoCore-renesas) repository, which provides support for other boards based on Renesas microcontrollers in addition to the UNO R4 family. When the platform is installed manually for development or beta testing, the `renesas_uno` architecture is not appropriate and so the convention is to instead use the general `renesas` architecture for manual installations of the platform. For this reason, the `renesas` architecture was also added to the field in order to support the use of the library with manually installed copies of the platform in addition to Boards Manager installations.

---

Originally reported at https://forum.arduino.cc/t/timer-interrupt-uno-r4-minima/1146816/9